### PR TITLE
Remove licenseServerCommand from "no licenseServer" branch

### DIFF
--- a/releases/R2021a/azuredeploy-R2021a-test.json
+++ b/releases/R2021a/azuredeploy-R2021a-test.json
@@ -268,7 +268,7 @@
                         "typeHandlerVersion": "1.10",
                         "autoUpgradeMinorVersion": true,
                         "protectedSettings": {
-                            "commandToExecute": "[concat(variables('stopSpoolerServiceCommand'),';',variables('licenseServerCommand'),';',variables('warmupMatlabCommand'))]"
+                            "commandToExecute": "[concat(variables('stopSpoolerServiceCommand'),';',variables('warmupMatlabCommand'))]"
                         }
                     },
                     "condition": "[equals(variables('licenseServer'),'mhlm')]"

--- a/releases/R2021a/azuredeploy-R2021a.json
+++ b/releases/R2021a/azuredeploy-R2021a.json
@@ -258,7 +258,7 @@
             "typeHandlerVersion": "1.10",
             "autoUpgradeMinorVersion": true,
             "protectedSettings": {
-              "commandToExecute": "[concat(variables('stopSpoolerServiceCommand'),';',variables('licenseServerCommand'),';',variables('warmupMatlabCommand'))]"
+              "commandToExecute": "[concat(variables('stopSpoolerServiceCommand'),';',variables('warmupMatlabCommand'))]"
             }
           },
           "condition": "[equals(variables('licenseServer'),'mhlm')]"

--- a/releases/R2021a/azuredeploy-existing-vnet-R2021a-test.json
+++ b/releases/R2021a/azuredeploy-existing-vnet-R2021a-test.json
@@ -280,7 +280,7 @@
                         "typeHandlerVersion": "1.10",
                         "autoUpgradeMinorVersion": true,
                         "protectedSettings": {
-                            "commandToExecute": "[concat(variables('stopSpoolerServiceCommand'),';',variables('licenseServerCommand'),';',variables('warmupMatlabCommand'))]"
+                            "commandToExecute": "[concat(variables('stopSpoolerServiceCommand'),';',variables('warmupMatlabCommand'))]"
                         }
                     },
                     "condition": "[equals(variables('licenseServer'),'mhlm')]"

--- a/releases/R2021a/azuredeploy-existing-vnet-R2021a.json
+++ b/releases/R2021a/azuredeploy-existing-vnet-R2021a.json
@@ -270,7 +270,7 @@
             "typeHandlerVersion": "1.10",
             "autoUpgradeMinorVersion": true,
             "protectedSettings": {
-              "commandToExecute": "[concat(variables('stopSpoolerServiceCommand'),';',variables('licenseServerCommand'),';',variables('warmupMatlabCommand'))]"
+              "commandToExecute": "[concat(variables('stopSpoolerServiceCommand'),';',variables('warmupMatlabCommand'))]"
             }
           },
           "condition": "[equals(variables('licenseServer'),'mhlm')]"


### PR DESCRIPTION
* Remove `licenseServerCommand` from being run in protectedSettings
  for `licenseServer=false` branch
* Issue was introduced by [3012cdfcb3f5f5f6ee1a3f653b79d47b5168ef24](https://github.com/mathworks-ref-arch/matlab-on-azure-win/commit/3012cdfcb3f5f5f6ee1a3f653b79d47b5168ef24)